### PR TITLE
Lights: Update deadband to 5% and median window to 9

### DIFF
--- a/lighting/code/src/main.py
+++ b/lighting/code/src/main.py
@@ -99,13 +99,13 @@ class LightingController:
 
     # Median filter window over raw samples, to reject single-sample
     # outliers that pass the ISR range gate.
-    MEDIAN_WINDOW = 5
+    MEDIAN_WINDOW = 9
 
     # Signal loss timeout - lights off if no PWM edges for this long
     SIGNAL_TIMEOUT_MS = 1000
 
     # Minimum brightness change (%) before updating lights (deadband)
-    LEVEL_DEADBAND = 2
+    LEVEL_DEADBAND = 5
 
     # Control loop interval
     LOOP_INTERVAL_MS = 50


### PR DESCRIPTION
This changes addresses the final small flickering seen in https://github.com/Seattle-Aquarium/CCR_development/issues/34#issuecomment-4315376147

I changed two parameters: 

- Bump LEVEL_DEADBAND from 2 → 5 — cleanly fixes the 79↔81 / 98↔99 flicker.
- Widen MEDIAN_WINDOW from 5 → 9 (~180ms at 50ms loop). Kills the sustained-burst glitches that currently sneak through. Tradeoff: ~90ms extra lag on intentional brightness changes, which is imperceptible to an operator.